### PR TITLE
IOS: Fix RTL icon support 

### DIFF
--- a/lib/src/tiles/platforms/ios_settings_tile.dart
+++ b/lib/src/tiles/platforms/ios_settings_tile.dart
@@ -158,7 +158,7 @@ class IOSSettingsTileState extends State<IOSSettingsTile> {
               data: IconTheme.of(context)
                   .copyWith(color: theme.themeData.leadingIconsColor),
               child: Icon(
-                CupertinoIcons.chevron_forward,
+                CupertinoIcons.forward,
                 size: 18 * scaleFactor,
               ),
             ),


### PR DESCRIPTION
fix: use CupertinoIcons.forward for iOS settings tile, instead of chevron_forward. This ensures correct right-to-left behavior in languages like Arabic. Fixes #32.